### PR TITLE
Fix min-height issue on landing page

### DIFF
--- a/browser/scss/home/main.scss
+++ b/browser/scss/home/main.scss
@@ -127,13 +127,10 @@ a {
 		@media all and (max-width: 1199px) and (min-width: 826px) {
 			width: 100%;
 		}
-		@media all and (max-width: 825px) and (min-width: 486px) {
+		@media all and (max-width: 825px) {
 			flex-direction: column;
-		}
-		@media all and (max-width: 485px) {
-			margin-top: auto;
-			margin-bottom: auto;
-			flex-direction: column;
+			padding-bottom: 80px;
+			padding-top: 80px;
 		}
 	}
 


### PR DESCRIPTION
There was an issue where if you shortened your screen size on the landing page, the buttons would move around. This should fix that.
