### PR TITLE
Text and content changes

### DIFF
--- a/browser/js/advisors/advisors.template.html
+++ b/browser/js/advisors/advisors.template.html
@@ -1,4 +1,5 @@
 <section class='advisory'>
+
 	<title>Kinetic's Advisory Network helps guide current members</title>
 	<meta name="description" content="Kinetic Advisors will aide current members with their expertise and knowledge to overcome obstacles and provide valuable feedback">
 

--- a/browser/scss/advisors/main.scss
+++ b/browser/scss/advisors/main.scss
@@ -15,7 +15,6 @@
 	.advisors {
 		padding: 30px 0;
 		display: flex;
-		justify-content: center;
 		flex-wrap: wrap;
 		flex-basis: 100%;
 		@media all and (max-width: 767px) {

--- a/browser/scss/mentors/main.scss
+++ b/browser/scss/mentors/main.scss
@@ -1,4 +1,6 @@
 .mentors {
+	margin: 0 auto;
+	max-width: 1280px;
 
 	.header {
 		padding: 30px;
@@ -32,6 +34,10 @@
 			padding: 15px 30px;
 			text-align: center;
 			flex-basis: calc(50% - 60px);
+
+			@media all and (max-width: 669px) {
+				flex-basis: 100%;
+			}
 
 			img {
 				width: 200px;


### PR DESCRIPTION
Problem One: Nav-bar was overlapping content on the advisors page.
Problem Two: On the mentors page the mentors were not in a single column but we're still in a grid layout because there was no media query to change the flex-basis of the .mentor css class.

Solution One: Remove unnecessary justify-content: center css from the scss for the advisors page 
Solution Two: Add in a media query for the px width at which the flex-basis should change and make the flex-basis: 100%